### PR TITLE
feat(fits): enable image parsing and example

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -22,22 +22,21 @@ pub fn build(b: *std.Build) void {
         .use_llvm = use_llvm,
     });
 
-    // Currently not using cfitsio or zigimg due to breaking on the master branch
-    // const zigimg_dependency = b.dependency("zigimg", .{
-    //     .target = target,
-    //     .optimize = optimize,
-    // });
-    //
-    // lib.root_module.addImport("zigimg", zigimg_dependency.module("zigimg"));
-    // astroz_mod.addImport("zigimg", zigimg_dependency.module("zigimg"));
+    const zignal_dependency = b.dependency("zignal", .{
+        .target = target,
+        .optimize = optimize,
+    });
 
-    // const cfitsio_dep = b.dependency("cfitsio", .{
-    //     .target = target,
-    //     .optimize = optimize,
-    // });
-    //
-    // lib.root_module.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
-    // astroz_mod.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
+    lib.root_module.addImport("zignal", zignal_dependency.module("zignal"));
+    astroz_mod.addImport("zignal", zignal_dependency.module("zignal"));
+
+    const cfitsio_dep = b.dependency("cfitsio", .{
+        .target = target,
+        .optimize = optimize,
+    });
+
+    lib.root_module.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
+    astroz_mod.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
 
     const lib_install = b.addInstallArtifact(lib, .{});
     lib_step.dependOn(&lib_install.step);
@@ -79,8 +78,8 @@ pub fn build(b: *std.Build) void {
         .root_module = astroz_mod,
     });
 
-    // tests.root_module.addImport("zigimg", zigimg_dependency.module("zigimg"));
-    // tests.root_module.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
+    tests.root_module.addImport("zignal", zignal_dependency.module("zignal"));
+    tests.root_module.addImport("cfitsio", cfitsio_dep.module("cfitsio"));
 
     const tests_run = b.addRunArtifact(tests);
     tests_step.dependOn(&tests_run.step);
@@ -115,5 +114,5 @@ const EXAMPLE_NAMES = &.{
     "precess_star",
     "simple_spacecraft_orientation",
     "transfer_propagation",
-    // "parse_fits_image",
+    "parse_fits_image",
 };

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,9 +4,13 @@
     .fingerprint = 0x2d8583fca695159f, // Changing this has security and trust implications.
     .minimum_zig_version = "0.15.0-dev.1031+61eff7b6d",
     .dependencies = .{
-        .zigimg = .{
-            .url = "git+https://github.com/zigimg/zigimg.git#29ff47f9e011065460d1d049cdc18784d733e23b",
-            .hash = "12201c288e763fb7d7e3207a638498faa439124e231d6f0cbcd4ebc618f706164ea8",
+        .cfitsio = .{
+            .url = "https://github.com/arrufat/cfitsio/archive/fbd70ae1144ea0eecbd8614179e3ff2e0ded31e9.tar.gz",
+            .hash = "cfitsio-4.6.2-LaSYAH0YAADk_V1sTcucNTxSJsQC5e3jZMzgniWQwTdb",
+        },
+        .zignal = .{
+            .url = "https://github.com/bfactory-ai/zignal/archive/refs/tags/0.4.1.tar.gz",
+            .hash = "zignal-0.4.1-OrZ3s9agDwDpPhRcFDfe3jVA2PVPjasQ3WZTuHUsfio6",
         },
     },
     .paths = .{

--- a/examples/parse_fits_image.zig
+++ b/examples/parse_fits_image.zig
@@ -1,0 +1,12 @@
+const std = @import("std");
+const astroz = @import("astroz");
+const Fits = astroz.Fits;
+
+pub fn main() !void {
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    defer _ = gpa.deinit();
+    const allocator = gpa.allocator();
+
+    var fitsPng = try Fits.open_and_parse("test/sample_fits.fits", allocator);
+    defer fitsPng.close();
+}

--- a/src/Fits.zig
+++ b/src/Fits.zig
@@ -1,5 +1,5 @@
 const std = @import("std");
-const zigimg = @import("zigimg");
+const zignal = @import("zignal");
 const cfitsio = @import("cfitsio").c;
 
 const Fits = @This();
@@ -137,8 +137,9 @@ pub fn readTable(self: *Fits, hdu_number: c_int, output_path: ?[]const u8) !void
     }
 
     defer file.close();
-    var buffered_writer = std.io.bufferedWriter(file.writer());
-    var buffered = buffered_writer.writer();
+    var write_buffer: [4096]u8 = undefined;
+    var file_writer = file.writer(&write_buffer);
+    var buffered = &file_writer.interface;
 
     // Write column headers
     var i: c_int = 1;
@@ -196,7 +197,7 @@ pub fn readTable(self: *Fits, hdu_number: c_int, output_path: ?[]const u8) !void
         }
         try buffered.writeAll("\n");
     }
-    try buffered_writer.flush();
+    try file_writer.interface.flush();
     std.log.debug("Finished processing all columns and rows. CSV file created: {any}\n", .{file});
 }
 
@@ -266,15 +267,15 @@ fn applyStretch(self: *Fits, pixels: []f32, width: usize, height: usize, output_
     const vmin = sorted_pixels[vmin_idx];
     const vmax = sorted_pixels[vmax_idx];
 
-    var image = try zigimg.Image.create(self.allocator, width, height, .rgb24);
-    defer image.deinit();
+    var image: zignal.Image(zignal.Rgb) = try .initAlloc(self.allocator, height, width);
+    defer image.deinit(self.allocator);
 
     for (pixels, 0..) |pixel, i| {
         const normalized = std.math.clamp((pixel - vmin) / (vmax - vmin), 0, 1);
         const stretched = sineStretch(normalized, options);
         const color = applyColorMap(stretched);
 
-        image.pixels.rgb24[i] = .{
+        image.data[i] = .{
             .r = @intFromFloat(color[0] * 255),
             .g = @intFromFloat(color[1] * 255),
             .b = @intFromFloat(color[2] * 255),
@@ -291,10 +292,10 @@ fn applyStretch(self: *Fits, pixels: []f32, width: usize, height: usize, output_
     var output_path_buffer: [std.fs.max_path_bytes]u8 = undefined;
     if (output_path) |op| {
         const output = try std.fmt.bufPrint(&output_path_buffer, "{s}/{s}.png", .{ file_name, op });
-        try image.writeToFilePath(output, .{ .png = .{} });
+        try image.save(self.allocator, output);
     } else {
         const output = try std.fmt.bufPrint(&output_path_buffer, "{s}/{s}.png", .{ file_name, file_name });
-        try image.writeToFilePath(output, .{ .png = .{} });
+        try image.save(self.allocator, output);
     }
 }
 

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -12,7 +12,7 @@ pub const EquatorialCoordinateSystem = @import("EquatorialCoordinateSystem.zig")
 pub const WorldCoordinateSystem = @import("WorldCoordinateSystem.zig");
 pub const OrbitalMechanics = @import("OrbitalMechanics.zig");
 pub const Mission = @import("Mission.zig");
-// pub const Fits = @import("Fits.zig");
+pub const Fits = @import("Fits.zig");
 
 test {
     std.testing.refAllDecls(@This());


### PR DESCRIPTION
Re-enables FITS image parsing using `cfitsio` and `zignal`. Replaces `zigimg` with `zignal` for image processing. Adds `parse_fits_image.zig` example.