### PR TITLE
macos dynamic lib

### DIFF
--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -2,6 +2,9 @@
 
 High-performance SGP4 satellite orbit propagation for Python, powered by Zig with SIMD acceleration.
 
+**Supported platforms:** macOS and Linux
+**Requires:** Python 3.12+
+
 ## Quick Start
 
 ```python
@@ -66,15 +69,9 @@ sgp4.propagate_into(times, positions, velocities)
 
 ## Building
 
-Requires [Zig](https://ziglang.org/) and Python 3.10+.
+Requires [Zig](https://ziglang.org/) and Python 3.12+.
 
 ```bash
-zig build python-bindings \
-  -Dpython-include=$(python -c "import sysconfig; print(sysconfig.get_path('include'))") \
-  -Dpython-lib=python3.12 \
-  -Dpython-lib-path=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))") \
-  -Doptimize=ReleaseFast
-
-cp zig-out/bindings/python/astroz/lib_astroz.so bindings/python/astroz/_astroz.so
-pip install -e bindings/python
+cd bindings/python
+pip install -e .
 ```

--- a/bindings/python/pyproject.toml
+++ b/bindings/python/pyproject.toml
@@ -7,7 +7,7 @@ name = "astroz"
 version = "0.3.0"
 description = "Python bindings for astroz - high-performance astrodynamics library"
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.12"
 license = {text = "MIT"}
 keywords = ["astrodynamics", "orbital-mechanics", "sgp4", "tle", "satellite"]
 classifiers = [
@@ -17,9 +17,10 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
+dependencies = ["numpy"]
 
 [project.optional-dependencies]
-dev = ["numpy", "sgp4"]  # For benchmarks and testing
+dev = ["sgp4"]  # For benchmarks and testing
 
 [project.urls]
 Repository = "https://github.com/ATTron/astroz"

--- a/bindings/python/setup.py
+++ b/bindings/python/setup.py
@@ -35,13 +35,16 @@ class ZigBuildExt(build_ext):
             "build",
             "python-bindings",
             f"-Dpython-include={python_include}",
-            f"-Dpython-lib={python_lib}",
             "-Doptimize=ReleaseFast",
         ]
 
-        # Add library path if it exists
-        if python_lib_dir and Path(python_lib_dir).exists():
-            cmd.append(f"-Dpython-lib-path={python_lib_dir}")
+        # On non-macOS platforms, link against Python library
+        # On macOS, Python extensions should NOT link against the Python library -
+        # symbols resolve at runtime when loaded by the interpreter
+        if sys.platform != "darwin":
+            cmd.append(f"-Dpython-lib={python_lib}")
+            if python_lib_dir and Path(python_lib_dir).exists():
+                cmd.append(f"-Dpython-lib-path={python_lib_dir}")
 
         print(f"Building with: {' '.join(cmd)}")
         subprocess.check_call(cmd, cwd=project_root)


### PR DESCRIPTION
fixed #57 

Root: was hardcoding the python link, but you typically dont build w system python on macos which caused the breaking. Tested this on my mac machine and things seemed to work okay there. Also I noticed the minimum version of python is too low, so bumped it up to the LTS (3.12)