### PR TITLE
Update zignal dependency

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -9,8 +9,8 @@
             .hash = "cfitsio-4.6.2-LaSYAD8ZAADmDI5X4e906pIVSb_dmIXrMYhm0PNVondp",
         },
         .zignal = .{
-            .url = "git+https://github.com/bfactory-ai/zignal#981b576f7e76099c4dee623c569c77ce2e62bb73",
-            .hash = "zignal-0.10.0-dev-OrZ3s1_0JQAZVpXgsqjgcvAHGayjOFzCRlKxVdy3T6yp",
+            .url = "git+https://github.com/arrufat/zignal#2db97fcf6b95222b9c0568a129f93d1a72f5f494",
+            .hash = "zignal-0.10.0-dev-OrZ3sxJyJgATX9TyC9k2sFPlGmwaMav02bCxSKQvyfZr",
         },
     },
     .paths = .{

--- a/src/Fits.zig
+++ b/src/Fits.zig
@@ -246,8 +246,8 @@ pub fn readImage(self: *Fits, hdu_number: c_int, output_path: ?[]const u8, optio
 
     // this checks if the image would be empty
     if (naxes[0] > 0 and naxes[1] > 0) {
-        const width: usize = @intCast(naxes[0]);
-        const height: usize = @intCast(naxes[1]);
+        const width: u32 = @intCast(naxes[0]);
+        const height: u32 = @intCast(naxes[1]);
         const pixels: []f32 = try self.allocator.alloc(f32, width * height);
         defer self.allocator.free(pixels);
 
@@ -343,7 +343,7 @@ pub fn readImageAsTable(self: *Fits, hdu_number: c_int, output_path: ?[]const u8
     }
 }
 
-fn applyStretch(self: *Fits, pixels: []f32, width: usize, height: usize, output_path: ?[]const u8, options: StretchOptions) !void {
+fn applyStretch(self: *Fits, pixels: []f32, width: u32, height: u32, output_path: ?[]const u8, options: StretchOptions) !void {
     const sorted_pixels = try self.allocator.dupe(f32, pixels);
     defer self.allocator.free(sorted_pixels);
     std.sort.heap(f32, sorted_pixels, {}, std.sort.asc(f32));


### PR DESCRIPTION
Zignal has been transferred to my GitHub account.
Also I changed the image rows/cols type from `usize` to `u32`.
And the PNG format is now using the `std.compress.flate` instead of my custom implementation.

As far as I know, you're the only one depending on Zignal, so I wanted to make sure everything still works.