### PR TITLE
fix: adapt to Zig 0.17 API changes

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -28,22 +28,37 @@ pub fn build(b: *std.Build) void {
 
     // CSPICE setup
     if (enable_cspice) {
-        if (cspice_include) |inc| {
-            astroz_mod.addIncludePath(.{ .cwd_relative = inc });
-        } else {
-            astroz_mod.addIncludePath(.{ .cwd_relative = "/usr/include" });
-            astroz_mod.addIncludePath(.{ .cwd_relative = "/usr/local/include" });
-            astroz_mod.addIncludePath(.{ .cwd_relative = "/usr/local/include/cspice" });
-            astroz_mod.addIncludePath(.{ .cwd_relative = "/opt/cspice/include" });
+        // Collect include search paths
+        const inc_paths: []const []const u8 = if (cspice_include) |inc| &.{inc} else &.{
+            "/usr/include",
+            "/usr/local/include",
+            "/usr/local/include/cspice",
+            "/opt/cspice/include",
+        };
+
+        // C source compilation include paths (needed for @cImport replacement)
+        for (inc_paths) |p| {
+            astroz_mod.addIncludePath(.{ .cwd_relative = p });
         }
 
         if (cspice_lib) |lib_path| {
             astroz_mod.addObjectFile(.{ .cwd_relative = lib_path });
         } else {
-            // Try AUR location first, then fallback to standard locations
             astroz_mod.addObjectFile(.{ .cwd_relative = "/usr/lib/cspice.a" });
         }
         astroz_mod.link_libc = true;
+
+        // C → Zig bindings via translate-c
+        const cspice_c = b.addTranslateC(.{
+            .root_source_file = .{ .cwd_relative = std.fmt.allocPrint(b.allocator, "{s}/SpiceUsr.h", .{inc_paths[0]}) catch @panic("OOM") },
+            .target = target,
+            .optimize = optimize,
+        });
+        for (inc_paths) |p| {
+            cspice_c.addIncludePath(.{ .cwd_relative = p });
+        }
+
+        astroz_mod.addImport("cspice_c", cspice_c.createModule());
     }
 
     // Library
@@ -240,8 +255,8 @@ pub fn build(b: *std.Build) void {
 
     const fmt = b.addFmt(.{
         .paths = &.{
-            "src/",
-            "build.zig",
+            b.path("src/"),
+            b.path("build.zig"),
         },
         .check = true,
     });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,11 +2,20 @@
     .name = .astroz,
     .version = "0.12.0",
     .fingerprint = 0x2d8583fca695159f, // Changing this has security and trust implications.
-    .minimum_zig_version = "0.16.0",
+    .minimum_zig_version = "0.17.0-dev.956+2dca73595",
     .dependencies = .{
-        .cfitsio = .{ .path = "../cfitsio" },
-        .zignal = .{ .path = "../zignal" },
-        .oma = .{ .path = "../oma" },
+        .cfitsio = .{
+            .url = "git+https://github.com/ATTron/cfitsio/#2faa5c5b263e0c4a903d7bbf54bb71a4597e876c",
+            .hash = "cfitsio-4.6.2-LaSYACsZAAD1UX_WWiQXcsBWwPnoMjwMzBA7WFNw8Xu2",
+        },
+        .zignal = .{
+            .url = "git+https://github.com/arrufat/zignal#3175ddb504c1a9dc86a0c1dcc700a6d8c06646c0",
+            .hash = "zignal-0.10.0-dev-OrZ3s9AAKADY_ZUA28rmpJqbEVBEoTtnkEdLebkrm_Ig",
+        },
+        .oma = .{
+            .url = "git+https://github.com/ATTron/oma#4d21951ead81571800298a20b04aa62673fa475b",
+            .hash = "oma-0.0.1-lqmw5RItAABkBRXop9wBptV8bB8pObT2bSvkz0jgsrdC",
+        },
     },
     .paths = .{
         "src/",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,18 +4,9 @@
     .fingerprint = 0x2d8583fca695159f, // Changing this has security and trust implications.
     .minimum_zig_version = "0.16.0",
     .dependencies = .{
-        .cfitsio = .{
-            .url = "git+https://github.com/ATTron/cfitsio/#2faa5c5b263e0c4a903d7bbf54bb71a4597e876c",
-            .hash = "cfitsio-4.6.2-LaSYACsZAAD1UX_WWiQXcsBWwPnoMjwMzBA7WFNw8Xu2",
-        },
-        .zignal = .{
-            .url = "git+https://github.com/arrufat/zignal#3175ddb504c1a9dc86a0c1dcc700a6d8c06646c0",
-            .hash = "zignal-0.10.0-dev-OrZ3s9AAKADY_ZUA28rmpJqbEVBEoTtnkEdLebkrm_Ig",
-        },
-        .oma = .{
-            .url = "git+https://github.com/ATTron/oma#4d21951ead81571800298a20b04aa62673fa475b",
-            .hash = "oma-0.0.1-lqmw5RItAABkBRXop9wBptV8bB8pObT2bSvkz0jgsrdC",
-        },
+        .cfitsio = .{ .path = "../cfitsio" },
+        .zignal = .{ .path = "../zignal" },
+        .oma = .{ .path = "../oma" },
     },
     .paths = .{
         "src/",

--- a/examples/create_ccsds_packet_config.zig
+++ b/examples/create_ccsds_packet_config.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     var dbga = std.heap.DebugAllocator(.{}).init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     const configFile = try std.Io.Dir.cwd().readFileAlloc(io, "examples/create_ccsds_packet_config.json", allocator, .limited(512));
     defer allocator.free(configFile);

--- a/examples/maneuver_planning.zig
+++ b/examples/maneuver_planning.zig
@@ -11,7 +11,7 @@ const constants = astroz.constants;
 const propagators = astroz.propagators;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.SafeAllocator.init(std.heap.page_allocator, .{});
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/parse_ccsds.zig
+++ b/examples/parse_ccsds.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     var dbga = std.heap.DebugAllocator(.{}).init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     const fileName = "./test/ccsds.bin".*;
 

--- a/examples/parse_ccsds_file_sync.zig
+++ b/examples/parse_ccsds_file_sync.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     var dbga = std.heap.DebugAllocator(.{}).init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     const fileName = "./test/ccsds.bin".*;
     const syncPattern = .{ 0x78, 0x97, 0xC0, 0x00, 0x00, 0x0A, 0x01, 0x02 };

--- a/examples/parse_fits_file.zig
+++ b/examples/parse_fits_file.zig
@@ -6,7 +6,7 @@ pub fn main() !void {
     var dbga: std.heap.DebugAllocator(.{}) = .init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     var fitsPng: Fits = try .open_and_parse("test/sample_fits.fits", io, allocator, .{ .createImages = true, .stretchOptions = .{ .stretch = 0.2 } });
     defer fitsPng.close();

--- a/examples/parse_vita49.zig
+++ b/examples/parse_vita49.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     var dbga = std.heap.DebugAllocator(.{}).init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     const file_name = "./test/vita49.bin".*;
     const sync_pattern = .{ 0x3A, 0x02, 0x0a, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x56 };

--- a/examples/parse_vita49_callback.zig
+++ b/examples/parse_vita49_callback.zig
@@ -7,7 +7,7 @@ pub fn main() !void {
     var dbga = std.heap.DebugAllocator(.{}).init;
     defer _ = dbga.deinit();
     const allocator = dbga.allocator();
-    const io = std.Io.Threaded.global_single_threaded.ioBasic();
+    const io = std.Io.Threaded.global_single_threaded.io();
 
     const file_name = "./test/vita49.bin".*;
     const sync_pattern = .{ 0x3A, 0x02, 0x0a, 0x00, 0x34, 0x12, 0x00, 0x00, 0x00, 0x56 };

--- a/examples/propagation.zig
+++ b/examples/propagation.zig
@@ -7,7 +7,7 @@ const constants = astroz.constants;
 const propagators = astroz.propagators;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.SafeAllocator.init(std.heap.page_allocator, .{});
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/simple_monte_carlo.zig
+++ b/examples/simple_monte_carlo.zig
@@ -4,7 +4,7 @@ const MonteCarlo = astroz.MonteCarlo;
 const constants = astroz.constants;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.SafeAllocator.init(std.heap.page_allocator, .{});
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/spice_propagation.zig
+++ b/examples/spice_propagation.zig
@@ -5,7 +5,7 @@ const constants = astroz.constants;
 const propagators = astroz.propagators;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.SafeAllocator.init(std.heap.page_allocator, .{});
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/examples/transfer_propagation.zig
+++ b/examples/transfer_propagation.zig
@@ -6,7 +6,7 @@ const OrbitalMechanics = astroz.OrbitalMechanics;
 const constants = astroz.constants;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.SafeAllocator.init(std.heap.page_allocator, .{});
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 

--- a/src/Constellation.zig
+++ b/src/Constellation.zig
@@ -331,7 +331,7 @@ fn propagateImpl(
     ctx: PropCtx,
 ) void {
     const maxThreads = getMaxThreads();
-    var handles: [MaxThreads]?std.Thread = .{null} ** MaxThreads;
+    var handles: [MaxThreads]?std.Thread = @splat(null);
     var idx: usize = 0;
 
     // SGP4 phase: thread over time ranges (timeMajor) or batch ranges (satelliteMajor)

--- a/src/Sdp4Batch.zig
+++ b/src/Sdp4Batch.zig
@@ -150,8 +150,7 @@ pub fn initFromElements(comptime N: usize, els: [N]Sdp4.Elements, grav: constant
 
     // Reflection based transpose: match batch field names to source paths
     @setEvalBranchQuota(10000);
-    inline for (@typeInfo(Batch).@"struct".fields) |field| {
-        const name = field.name;
+    inline for (@typeInfo(Batch).@"struct".field_names) |name| {
         if (comptime std.mem.startsWith(u8, name, "solar_")) {
             const suffix = comptime name["solar_".len..];
             var arr: [N]f64 = undefined;

--- a/src/Sgp4Batch.zig
+++ b/src/Sgp4Batch.zig
@@ -84,13 +84,13 @@ pub fn initBatchElements(comptime N: usize, tles: [N]Tle, grav: constants.Sgp4Gr
     var result: BatchElements(N) = undefined;
 
     // Transpose matching fields automatically
-    inline for (@typeInfo(BatchElements(N)).@"struct".fields) |field| {
-        if (@hasField(Elements, field.name)) {
+    inline for (@typeInfo(BatchElements(N)).@"struct".field_names) |name| {
+        if (@hasField(Elements, name)) {
             var arr: [N]f64 = undefined;
             inline for (0..N) |i| {
-                arr[i] = @field(els[i], field.name);
+                arr[i] = @field(els[i], name);
             }
-            simdMath.storeArray(N, &@field(result, field.name), arr);
+            simdMath.storeArray(N, &@field(result, name), arr);
         }
     }
 

--- a/src/Spice.zig
+++ b/src/Spice.zig
@@ -13,9 +13,7 @@ const buildOptions = @import("build_options");
 pub const enabled = buildOptions.enable_cspice;
 
 /// Raw CSPICE C bindings (only available when enabled)
-pub const c = if (enabled) @cImport({
-    @cInclude("SpiceUsr.h");
-}) else struct {
+pub const c = if (enabled) @import("cspice_c") else struct {
     pub const SpiceInt = c_int;
     pub const SpiceBoolean = c_int;
 };


### PR DESCRIPTION
- SPICE: replace deprecated @cImport with addTranslateC in build.zig
- Sdp4Batch/Sgp4Batch: replace .fields with .field_names
- Examples: replace GeneralPurposeAllocator with SafeAllocator
- Examples: replace ioBasic() with io()
- build.zig: fix formatting issues